### PR TITLE
Add simple ChatGPT web demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # codex
 # 🤖 kymbob’s Kopilot
 
-Welcome to **kymbob’s Kopilot** — my personal AI-powered coding assistant.  
+Welcome to **kymbob’s Kopilot** — my personal AI-powered coding assistant.
 This repo is where I experiment with **local LLMs**, **custom APIs**, and **VS Code integrations** to create a self-hosted alternative to GitHub Copilot.
 
 ---
 
 ## ✨ Features
-- 🧠 **ChatGPT / LLM Integration** – connect to local or cloud models (Ollama, AnythingLLM, LocalAI, OpenAI API)  
-- 🖥 **VS Code Support** – works with [Continue.dev](https://continue.dev) or REST Client to chat directly inside the editor  
-- 🛠 **Automation Scripts** – helper tools for development + AI workflows  
-- 📂 **Prompt Library** – reusable prompts and templates  
+- 🧠 **ChatGPT / LLM Integration** – connect to local or cloud models (Ollama, AnythingLLM, LocalAI, OpenAI API)
+- 🖥 **VS Code Support** – works with [Continue.dev](https://continue.dev) or REST Client to chat directly inside the editor
+- 🛠 **Automation Scripts** – helper tools for development + AI workflows
+- 📂 **Prompt Library** – reusable prompts and templates
 
 ---
 
@@ -20,3 +20,15 @@ This repo is where I experiment with **local LLMs**, **custom APIs**, and **VS C
 ```bash
 git clone https://github.com/kymbob/codex.git
 cd codex
+```
+
+### 2. Run the ChatGPT demo web page
+Set your OpenAI API key and install dependencies:
+
+```bash
+export OPENAI_API_KEY="your-key"
+pip install -r requirements.txt
+python app.py
+```
+
+The app will run on [http://localhost:5000](http://localhost:5000). You can reverse-proxy it through Apache to serve on ports 80 or 443.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,23 @@
+import os
+from flask import Flask, request, jsonify, render_template
+from openai import OpenAI
+
+app = Flask(__name__)
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+@app.post("/generate")
+def generate():
+    data = request.get_json()
+    prompt = data.get("prompt", "")
+    completion = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return jsonify({"response": completion.choices[0].message.content})
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+openai

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Kopilot Chat</title>
+</head>
+<body>
+    <h1>Kopilot Chat</h1>
+    <textarea id="prompt" rows="4" cols="50" placeholder="Ask something..."></textarea><br>
+    <button id="send">Send</button>
+    <pre id="response"></pre>
+    <script>
+    document.getElementById('send').addEventListener('click', async () => {
+        const prompt = document.getElementById('prompt').value;
+        const res = await fetch('/generate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ prompt })
+        });
+        const data = await res.json();
+        document.getElementById('response').textContent = data.response;
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask app that proxies requests to OpenAI's chat completions API
- create basic HTML page to send prompts and display responses
- document setup and usage

## Testing
- `python -m py_compile app.py`
- `pytest` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68b2561e2f6c832faf2c31d12dbd3393